### PR TITLE
add a timeout to the requests

### DIFF
--- a/lib/zendesk_api/configuration.rb
+++ b/lib/zendesk_api/configuration.rb
@@ -49,6 +49,9 @@ module ZendeskAPI
           :accept_encoding => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
           :user_agent => "ZendeskAPI API #{ZendeskAPI::VERSION}"
         },
+        :request => {
+          :open_timeout => 2
+        },
         :url => @url
       }.merge(client_options)
     end


### PR DESCRIPTION
For reasons. Because there's no way we're actually still using this fork. Nope.
